### PR TITLE
GPU Prototype

### DIFF
--- a/GPU_network.jl
+++ b/GPU_network.jl
@@ -1,0 +1,124 @@
+using CUDA
+using LightGraphs
+using NetworkDynamics
+using BenchmarkTools
+
+@inline function diffusion_edge!(e,v_s,v_d,p,t)
+    e .= v_s .- v_d
+    nothing
+end
+staticedge = StaticEdge(f! = diffusion_edge!, dim = 1, coupling=:directed)
+
+@inline function diffusion_vertex_nd!(dv, v, edges, p, t)
+    dv .= 0.
+    sum_coupling!(dv, edges)
+    nothing
+end
+odevertex = ODEVertex(f! = diffusion_vertex_nd!,dim = 1)
+
+@inline function diffusion_vertex!(dv, v, agg::AbstractVector{<:AbstractFloat}, p, t)
+    dv .= agg
+    nothing
+end
+
+struct Network{FloatMat, IdxMat, Vertex, Edge, Aggr}
+    "vertex function (ODE)"
+    vfun::Vertex
+    "dimensions of edge function"
+    vdim::Int
+    "edge function (static)"
+    efun::Edge
+    "dimensions of vertex function"
+    edim::Int
+    "Aggregation function"
+    aggfun::Aggr
+    "Matrix(2, #edges), [srcidx, dstidx] per column"
+    vidx_per_e::IdxMat
+    "Matrix(?, #vertices), [e1idx, e2idx,...] of *incoming* edges per column"
+    eidx_per_v::IdxMat
+    "cache matrix for the aggregation"
+    _aggregation::FloatMat
+    "cache matrix for the static edges"
+    _edge_u::FloatMat
+end
+
+function Network(; g::SimpleDiGraph, vf, vdim, ef, edim, aggf, AT=Array, FT=Float64)
+    edge_u = Matrix{FT}(undef, edim, ne(g))
+    aggregation = Matrix{FT}(undef, edim, nv(g))
+
+    vidx_per_e = Matrix{Int32}(undef, 2, ne(g))
+    for (i, e) in enumerate(edges(g))
+        vidx_per_e[:, i] .= [e.src, e.dst]
+    end
+
+    # indices of the outgoing edges
+    # i.e. find idx for occurences of v in the dst row of vidx_per_edge
+    eidx_per_v = zeros(Int, maximum(indegree(g)), nv(g))
+    for v in 1:nv(g)
+        eidx = findall(isequal(v), vidx_per_e[2, :])
+        eidx_per_v[1:length(eidx), v] .= eidx
+    end
+
+    Network(vf, vdim, ef, edim, aggf,
+            AT{Int32,2}(vidx_per_e),
+            AT{Int32,2}(eidx_per_v),
+            AT{FT,2}(aggregation),
+            AT{FT,2}(edge_u))
+end
+
+LightGraphs.ne(nw::Network) = size(nw.vidx_per_e, 2)
+LightGraphs.nv(nw::Network) = size(nw.eidx_per_v, 2)
+
+function (nw::Network{<:Matrix})(du, u, p, t)
+    # calculate edges
+    @inbounds for eidx in 1:ne(nw)
+        vu = view(nw._edge_u, :, eidx)
+        vs = view(u, :, nw.vidx_per_e[1, eidx])
+        vd = view(u, :, nw.vidx_per_e[2, eidx])
+        nw.efun(vu, vs, vd, p, t)
+    end
+
+    # aggregate edge values
+    fill!(nw._aggregation, 0)
+    @inbounds for vidx in 1:nv(nw)
+        agg = view(nw._aggregation, :, vidx)
+        for eidx in view(nw.eidx_per_v, :, vidx)
+            eidx == 0 && break # no more edges left
+            agg .+= view(nw._edge_u, :, eidx)
+        end
+    end
+
+    # calculate vertex functions
+    fill!(du, 0)
+    @inbounds for vidx in 1:nv(nw)
+        vdu = view(du, :, vidx)
+        vu  = view(du, :, vidx)
+        agg = view(nw._aggregation, :, vidx)
+        nw.vfun(vdu, vu, agg, p, t)
+    end
+end
+
+# function (nw::Network{<:CuMatrix})(du, u, p, t)
+#     println("GPU")
+# end
+
+# g = SimpleDiGraph(smallgraph(:house))
+g = SimpleDiGraph(watts_strogatz(1_000, 4, 0.5))
+
+nd = network_dynamics(odevertex, staticedge, g)
+nw = Network(; g, vf=diffusion_vertex!, vdim=1, ef=diffusion_edge!, edim=1, aggf=+)
+
+u = rand(1, nv(g))
+du = zeros(size(u)...)
+u_nd  = u[:] # copy and bring in right shape
+du_nd = du[:]
+
+nd(du_nd, u_nd, nothing, 0.0)
+nw(du, u, nothing, 0.0)
+# du_nd .- du[:]
+@assert du_nd ≈ du[:]
+
+@benchmark $nd($du_nd, $u_nd, nothing, 0.0)
+@benchmark $nw($du, $u, nothing, 0.0)
+
+# net_gpu = Network(; g, vf=nothing, vdim=1, ef=nothing, edim=1, AT=CuArray)

--- a/GPU_network.jl
+++ b/GPU_network.jl
@@ -4,20 +4,29 @@ using NetworkDynamics
 using BenchmarkTools
 
 @inline function diffusion_edge!(e,v_s,v_d,p,t)
-    e .= v_s .- v_d
+    @inbounds for i in 1:length(e)
+        e[i] = v_s[i] - v_d[i]
+    end
     nothing
 end
-staticedge = StaticEdge(f! = diffusion_edge!, dim = 1, coupling=:directed)
 
 @inline function diffusion_vertex_nd!(dv, v, edges, p, t)
-    dv .= 0.
+    fill!(dv, 0)
     sum_coupling!(dv, edges)
     nothing
 end
-odevertex = ODEVertex(f! = diffusion_vertex_nd!,dim = 1)
 
 @inline function diffusion_vertex!(dv, v, agg::AbstractVector{<:AbstractFloat}, p, t)
-    dv .= agg
+    @inbounds for i in 1:length(dv)
+        dv[i] = agg[i]
+    end
+    nothing
+end
+
+@inline function unsafe_add!(a, b)
+    @inbounds for i in 1:length(a)
+        a[i] += b[i]
+    end
     nothing
 end
 
@@ -72,10 +81,10 @@ LightGraphs.nv(nw::Network) = size(nw.eidx_per_v, 2)
 function (nw::Network{<:Matrix})(du, u, p, t)
     # calculate edges
     @inbounds for eidx in 1:ne(nw)
-        vu = view(nw._edge_u, :, eidx)
+        eu = view(nw._edge_u, :, eidx)
         vs = view(u, :, nw.vidx_per_e[1, eidx])
         vd = view(u, :, nw.vidx_per_e[2, eidx])
-        nw.efun(vu, vs, vd, p, t)
+        nw.efun(eu, vs, vd, p, t)
     end
 
     # aggregate edge values
@@ -84,41 +93,191 @@ function (nw::Network{<:Matrix})(du, u, p, t)
         agg = view(nw._aggregation, :, vidx)
         for eidx in view(nw.eidx_per_v, :, vidx)
             eidx == 0 && break # no more edges left
-            agg .+= view(nw._edge_u, :, eidx)
+            values = view(nw._edge_u, :, eidx)
+            nw.aggfun(agg, values)
         end
     end
 
-    # calculate vertex functions
-    fill!(du, 0)
+    # calculate vertex functions (needs  fill!(du, 0) ? )
     @inbounds for vidx in 1:nv(nw)
         vdu = view(du, :, vidx)
-        vu  = view(du, :, vidx)
+        vu  = view(u, :, vidx)
         agg = view(nw._aggregation, :, vidx)
         nw.vfun(vdu, vu, agg, p, t)
     end
 end
 
-# function (nw::Network{<:CuMatrix})(du, u, p, t)
-#     println("GPU")
-# end
+function edge_kernel!(efun, _edge_u, u, p, t, N, vidx_per_e)
+    eidx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if eidx <= N
+        eu = view(_edge_u, :, eidx)
+        vs = view(u, :, vidx_per_e[1, eidx])
+        vd = view(u, :, vidx_per_e[2, eidx])
+        efun(eu, vs, vd, nothing, t)
+    end
+    return nothing
+end
 
-# g = SimpleDiGraph(smallgraph(:house))
-g = SimpleDiGraph(watts_strogatz(1_000, 4, 0.5))
+function aggregation_kernel!(aggfun, _aggregation, _edge_u, N, eidx_per_v)
+    vidx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if vidx <= N
+        agg = view(_aggregation, :, vidx)
+        for eidx in view(eidx_per_v, :, vidx)
+            eidx == 0 && break # no more edges left
+            values = view(_edge_u, :, eidx)
+            aggfun(agg, values)
+        end
+    end
+    return nothing
+end
 
-nd = network_dynamics(odevertex, staticedge, g)
-nw = Network(; g, vf=diffusion_vertex!, vdim=1, ef=diffusion_edge!, edim=1, aggf=+)
+function vertex_kernel!(vfun, du, u, _aggregation, p, t, N)
+    vidx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if vidx <= N
+        vdu = view(du, :, vidx)
+        vu  = view(u, :, vidx)
+        agg = view(_aggregation, :, vidx)
+        vfun(vdu, vu, agg, p, t)
+    end
+end
 
-u = rand(1, nv(g))
-du = zeros(size(u)...)
-u_nd  = u[:] # copy and bring in right shape
-du_nd = du[:]
+function (nw::Network{<:CuMatrix})(du, u, p, t)
+    # edge loop
+    Ne, Nv = ne(nw), nv(nw)
+    numb = ceil(Int, Ne/256)
+    CUDA.@sync begin
+        @cuda threads=256 blocks=numb edge_kernel!(nw.efun, nw._edge_u,
+                                                   u, p, t,
+                                                   Ne, nw.vidx_per_e)
+    end
 
-nd(du_nd, u_nd, nothing, 0.0)
-nw(du, u, nothing, 0.0)
-# du_nd .- du[:]
-@assert du_nd ≈ du[:]
+    # aggregate edge values
+    numb = ceil(Int, Nv/256)
+    fill!(nw._aggregation, 0)
+    CUDA.@sync begin
+        @cuda threads=256 blocks=numb aggregation_kernel!(nw.aggfun,
+                                                          nw._aggregation,
+                                                          nw._edge_u,
+                                                          Nv, nw.eidx_per_v)
+    end
 
-@benchmark $nd($du_nd, $u_nd, nothing, 0.0)
-@benchmark $nw($du, $u, nothing, 0.0)
+    # calculate vertex functions (needs  fill!(du, 0) ? )
+    CUDA.@sync begin
+        @cuda threads=256 blocks=numb vertex_kernel!(nw.vfun,
+                                                     du, u,
+                                                     nw._aggregation,
+                                                     p, t, Nv)
+    end
+    return nothing
+end
 
-# net_gpu = Network(; g, vf=nothing, vdim=1, ef=nothing, edim=1, AT=CuArray)
+####
+#### lets benchmark nd, the GPU and the CPU verions
+####
+Nv = Int[]
+tnd = Float64[]
+tcpu = Float64[]
+tgpu = Float64[]
+for N in 1_000:1_000:10_000
+    @info "N = $N"
+    g = SimpleDiGraph(watts_strogatz(N, 4, 0.5))
+    vdim = 1
+    edim = 1
+    odevertex = ODEVertex(f! = diffusion_vertex_nd!,dim = vdim)
+    staticedge = StaticEdge(f! = diffusion_edge!, dim = edim, coupling=:directed)
+
+    nd = network_dynamics(odevertex, staticedge, g)
+    nw_cpu = Network(; g, vf=diffusion_vertex!, vdim, ef=diffusion_edge!, edim, aggf=unsafe_add!)
+    nw_gpu = Network(; g, vf=diffusion_vertex!, vdim, ef=diffusion_edge!, edim, aggf=unsafe_add!, AT=CuArray)
+
+    u_cpu = rand(vdim, nv(g));
+    du_cpu = zeros(size(u_cpu)...);
+    u_gpu = CuArray(u_cpu);
+    du_gpu = CuArray(du_cpu);
+    u_nd  = u_cpu[:]; # copy and bring in right shape
+    du_nd = du_cpu[:];
+
+    nd(du_nd, u_nd, nothing, 0.0)
+    nw_cpu(du_cpu, u_cpu, nothing, 0.0)
+    nw_gpu(du_gpu, u_gpu, nothing, 0.0)
+
+    # du_nd .- du[:]
+    @assert du_nd ≈ du_cpu[:]
+    @assert du_nd ≈ Array(du_gpu[:])
+
+    nd = @benchmark $nd($du_nd, $u_nd, nothing, 0.0)
+    cpu = @benchmark $nw_cpu($du_cpu, $u_cpu, nothing, 0.0)
+    gpu = @benchmark $nw_gpu($du_gpu, $u_gpu, nothing, 0.0)
+
+    push!(Nv, N)
+    push!(tnd, median(nd).time)
+    push!(tcpu, median(cpu).time)
+    push!(tgpu, median(gpu).time)
+end
+
+using UnicodePlots
+using Plots
+#results
+Nv = [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]
+tnd =  [31036.0, 64741.0, 100002.0, 136430.5, 169399.0, 208196.0, 245205.0, 284399.0, 317361.0, 352364.0]
+tcpu = [18987.0, 39246.0, 59190.0, 78887.0, 98959.0, 119536.0, 141710.0, 161325.0, 183985.0, 204158.0]
+tgpu = [27177.5, 24925.0, 26865.0, 24559.0, 24740.5, 25134.0, 25101.0, 25380.5, 25658.0, 26085.0]
+
+p = lineplot(log.(Nv), log.(tnd); name="nd", xlabel="log(N)", ylabel="log(t)", title="coreloop timings")
+lineplot!(p, log.(Nv), log.(tcpu); name="CPU")
+lineplot!(p, log.(Nv), log.(tgpu); name="GPU")
+
+using OrdinaryDiffEq
+using DiffEqGPU
+
+Nv = Int[]
+tnd = Float64[]
+tcpu = Float64[]
+tgpu = Float64[]
+for N in [10, 100, 1_000, 5_000, 10_000]
+    @info "N = $N"
+
+    g = SimpleDiGraph(watts_strogatz(N, 4, 0.5))
+    vdim = 1
+    edim = 1
+    odevertex = ODEVertex(f! = diffusion_vertex_nd!,dim = vdim)
+    staticedge = StaticEdge(f! = diffusion_edge!, dim = edim, coupling=:directed)
+
+    nd = network_dynamics(odevertex, staticedge, g)
+    nw_cpu = Network(; g, vf=diffusion_vertex!, vdim, ef=diffusion_edge!, edim, aggf=unsafe_add!)
+    nw_gpu = Network(; g, vf=diffusion_vertex!, vdim, ef=diffusion_edge!, edim, aggf=unsafe_add!, AT=CuArray)
+
+    u0_cpu = rand(vdim, nv(g));
+    u0_gpu = CuArray(u0_cpu);
+    u0_nd  = u0_cpu[:]; # copy and bring in right shape
+
+    tspan = (0., 100.)
+    prob_nd = ODEProblem(nd, u0_nd, tspan)
+    prob_cpu = ODEProblem(nw_cpu, u0_cpu, tspan)
+    prob_gpu = ODEProblem(nw_gpu, u0_gpu, tspan)
+
+    tsit_nd = solve(prob_nd, Tsit5());
+    tsit_cpu = solve(prob_cpu, Tsit5());
+    tsit_gpu = solve(prob_gpu, Tsit5());
+
+    @assert tsit_nd[end] ≈ tsit_cpu[end][:]
+    @assert tsit_nd[end] ≈ Array(tsit_gpu[end])[:]
+
+    nd =  @benchmark $solve($prob_nd, $Tsit5())
+    cpu = @benchmark $solve($prob_cpu, $Tsit5())
+    gpu = @benchmark $solve($prob_gpu, $Tsit5())
+
+    push!(Nv, N)
+    push!(tnd, median(nd).time)
+    push!(tcpu, median(cpu).time)
+    push!(tgpu, median(gpu).time)
+end
+# results
+Nv = [10, 100, 1000, 5000, 10000]
+tnd = [428508.0, 4.532003e6, 6.292465e7, 3.43278027e8, 8.17074963e8]
+tcpu = [280178.0, 2.562238e6, 3.87406555e7, 1.98708704e8, 4.57421916e8]
+tgpu = [5.7550438e7, 7.3006628e7, 9.169478e7, 9.8668921e7, 1.10475052e8]
+
+p = lineplot(log.(Nv), log.(tnd); name="nd", xlabel="log(N)", ylabel="log(t)", title="Tsit5() timings")
+lineplot!(p, log.(Nv), log.(tcpu); name="CPU")
+lineplot!(p, log.(Nv), log.(tgpu); name="GPU")

--- a/GPU_scratch.jl
+++ b/GPU_scratch.jl
@@ -1,0 +1,25 @@
+using CUDA
+using BenchmarkTools
+
+N = 2^20
+x = fill(1.0f0, N)  # a vector filled with 1.0 (Float32)
+y = fill(2.0f0, N)  # a vector filled with 2.0
+x_d = CuArray(x)
+y_d = CuArray(y)
+
+function gpu_add3!(y, x)
+    index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    @inbounds y[index] += x[index]
+    return
+end
+
+function bench_gpu3!(y, x)
+    numblocks = ceil(Int, length(y)/256)
+    CUDA.@sync begin
+        @cuda threads=256 blocks=numblocks gpu_add3!(y, x)
+    end
+end
+
+@btime bench_gpu3!($y_d, $x_d)
+
+@btime $x .+ $y

--- a/GPU_scratch.jl
+++ b/GPU_scratch.jl
@@ -1,25 +1,69 @@
 using CUDA
 using BenchmarkTools
+using UnicodePlots
 
-N = 2^20
-x = fill(1.0f0, N)  # a vector filled with 1.0 (Float32)
-y = fill(2.0f0, N)  # a vector filled with 2.0
-x_d = CuArray(x)
-y_d = CuArray(y)
+####
+#### most simple case, linear data
+####
 
-function gpu_add3!(y, x)
-    index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    @inbounds y[index] += x[index]
-    return
+function staticedge!(e, vs, vd)
+    @inbounds e[1] = sin(vs[1] - vd[1])
+    return nothing
 end
 
-function bench_gpu3!(y, x)
-    numblocks = ceil(Int, length(y)/256)
-    CUDA.@sync begin
-        @cuda threads=256 blocks=numblocks gpu_add3!(y, x)
+function loop(e::T, vs::T, vd::T) where {T<:Array}
+    for i in 1:length(vs)
+        staticedge!(view(e, i), view(vs, i), view(vd, i))
     end
+    return nothing
 end
 
-@btime bench_gpu3!($y_d, $x_d)
+function edge_kernel!(e, vs, vd, length)
+    index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if index <= length
+        staticedge!(view(e, index), view(vs, index), view(vd, index))
+    end
+    return nothing
+end
 
-@btime $x .+ $y
+function loop(e::T, vs::T, vd::T) where {T<:CuArray}
+    N = length(e)
+    numblocks = ceil(Int, N/256)
+    CUDA.@sync begin
+        @cuda threads=256 blocks=numblocks edge_kernel!(e, vs, vd, N)
+    end
+    return nothing
+end
+
+Nv = Int[]
+tcpu = Float64[]
+tgpu = Float64[]
+
+for N in [100, 500, 1000, 5000]
+    println(N)
+    vs = rand(Float32, N);
+    vd = rand(Float32, N);
+    e = zeros(Float32, N);
+    vs_d = CuArray(vs);
+    vd_d = CuArray(vd);
+    e_d = CuArray(e);
+
+    @assert Array(e_d) == e
+    @assert Array(vs_d) == vs
+    @assert Array(vd_d) == vd
+
+    loop(e, vs, vd)
+    loop(e_d, vs_d, vd_d)
+    @assert Array(e_d) ≈ e
+
+    cpu = @benchmark loop($e, $vs, $vd)
+    gpu = @benchmark loop($e_d, $vs_d, $vd_d)
+    # BenchmarkTools.judge(median(gpu), median(cpu))
+
+    push!(Nv, N)
+    push!(tcpu, median(cpu).time)
+    push!(tgpu, median(gpu).time)
+end
+
+p = lineplot(Nv, log.(tcpu); name="CPU")
+lineplot!(p, Nv, log.(tgpu); name="GPU")

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Frank Hellmann <hellmann@pik-potsdam.de>, Michael Lindner <michaelli
 version = "0.5.5"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Frank Hellmann <hellmann@pik-potsdam.de>, Michael Lindner <michaelli
 version = "0.5.5"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"


### PR DESCRIPTION
Hey! I thought it's about time to do some GPU experiments. I have working protoype for that in `GPU_network.jl`.

Since our whole GraphStructure/GraphData business is really complicated to bring to the GPU memory I went for a quit different approach implementing a toymodel first. The main idea is to split the network in homogeneous parts (as with the old network layer stuff or more recently in #91 ). Once we have homogeneous subsystems, maybe we don't need a lot of the complex structure anymore.

Thats why i decided to build a minimal working prototype first which only works for homogeneous systems. This mini example supports both, CPU and GPU. I compared all calculations against NetworkDyanamics. Here are some benchmarks for the coreloop:

![coreloop](https://user-images.githubusercontent.com/35867212/124716334-41b24f00-df04-11eb-9138-0911a779249b.png)

And some benchmarks for a solver run with `Tsit5()` (around 260 timesteps).

![tsit5solve](https://user-images.githubusercontent.com/35867212/124716343-45de6c80-df04-11eb-89d1-13ed9964ef4e.png)

As of now the prototype can't handle autodiff, thats why i've choosen the explicit solver...
