### PR TITLE
draft: start work on solution inspection tools

### DIFF
--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -256,6 +256,7 @@ end
     prepare_edges(edges, g::SimpleGraph)
 """
 function prepare_edges(edges::Vector, g::SimpleGraph)
+    ne(g) == length(edges) || error("If edges are given as Vector, size musst equal number of edges in g.")
     # Depending on the coupling we might get different eltypes
     new_edges = Vector{EdgeFunction}(undef, length(edges))
     infobool = true
@@ -280,6 +281,7 @@ end
 """
 """
 function prepare_edges(edges::Vector, g::SimpleDiGraph)
+    ne(g) == length(edges) || error("If edges are given as Vector, size musst equal number of edges in g.")
     # Depending on the coupling we might get different eltypes
     new_edges = Vector{EdgeFunction}(undef, length(edges))
     infobool = true
@@ -304,11 +306,8 @@ end
 
 
 @inline function reconstruct_edge(edge::StaticEdge, coupling::Symbol)
-    let f = edge.f, dim = edge.dim, sym = edge.sym
-        return StaticEdge(; f=f,
-                          dim=dim,
-                          coupling=coupling,
-                          sym=sym)
+    let f = edge.f, dim = edge.dim, sym = edge.sym, name=edge.name, psym=edge.psym, obsf=edge.obsf, obssym=edge.obssym
+        return StaticEdge(; f, dim, coupling, sym, name, psym, obsf, obssym)
     end
 end
 @inline function reconstruct_edge(edge::StaticDelayEdge, coupling::Symbol)

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -10,7 +10,7 @@ include("NetworkStructures.jl")
 include("NetworkDiffEq.jl")
 
 
-export network_dynamics
+export network_dynamics, allocation_report
 
 
 

--- a/test/ComponentFunctions_test.jl
+++ b/test/ComponentFunctions_test.jl
@@ -234,7 +234,7 @@ end
 
 
     vertex_list_1 = [odevertex for v in 1:10]
-    @test eltype(vertex_list_1) == ODEVertex{typeof(diffusion_vertex!)}
+    @test eltype(vertex_list_1) == ODEVertex{typeof(diffusion_vertex!), typeof(nothing)}
 
     vertex_list_2 = [staticvertex for v in 1:10]
     @test eltype(vertex_list_2) <: ODEVertex

--- a/test/diffusion_test.jl
+++ b/test/diffusion_test.jl
@@ -109,7 +109,7 @@ println("Building Static Network Dynamics with artifical ODE Edges...")
     x0_ode = find_valid_ic(diff_network_ode, randn(nv(g) + 2 * ne(g)))
     dx0_ode = similar(x0_ode)
     diff_network_ode(dx0_ode, x0_ode, nothing, 0.0)
-    @test_broken @allocated diff_network_ode(dx0_ode, x0_ode, nothing, 0.0) == 0.0
+    @test NetworkDynamics.allocations(diff_network_ode, nothing) == 0
 end
 
 @inline function real_ode_edge!(de, e, v_s, v_d, p, t)


### PR DESCRIPTION
This is the start of a new "solution inspection" interface which will be the base for a not-yet-relased package for interactive inspection of NetworkDynamic (and eventually PowerDynamics) solutions. Hopefully, this interface is also usefull for all sorts of solution inspection.

### Goals
The main goal of this interface is to be extensible behind the "normal" ode states, so it should also support
- edge states (both ode and static edges) (not yet implemented),
- "observed" states, i.e. algebraic equations which have been removed by MTK/BlockSystems (not yet implemented),
- "derived" states, which can by trivially constructed from other states.

### Interface
Currently, the interface works as follows:
```julia
u_r_f = vstatef(sol, p, 17, :u_r)
plot(sol.t, u_r_f(sol.t))
```
returns a *function*, which, applyed to `t` (such as `u_r_f(1.0)` or `u_r_f(0:0.1:10)`) returns the value of state `u_r` of vertex `17` in the solution `sol` using `p`. There is also an option to get several parameters at once like
```julia
u_ri_f = vstatef(sol, p, 17, [:u_r, :u_i])
```
not yet implemented but also planned is to get the same state for several nodes.
```julia
u_r_f = vstatef(sol, p, 1:10, :u_r)
```
which makes sense performance wise because we only need to evalue the rhs of the DGL once per timestep.

### "derived" states
Quite often when dealing with powergrids i find myself recalculating the same derived states again and again. Now it is possible to define "virtual" as algebraic functions of other states such as
```julia
@register_statelens :u_mag => sqrt(:u_r^2 + :u_i^2)
```
will allows to generate a timseries for `:u_mag` directly. Even better
```julia
@register_statelens r"^(.*)_arg$" => atan(s"\1_i", s"\1_r")
```
matches *every* symbol with ends with `_arg` so you will be able to generate argument timeseries for every pair of complex cart coordinates. Those definitions can depend on eachother
```julia
@register_statelens :_S => (:u_r + :u_i*im)*(:_i_r - :_i_i*im)
@register_statelens :_P => real(:_S)
@register_statelens :_Q => imag(:_S)
```
would allow direct access to `S`, `Q` and `P` for every node.

There is also an even more low level interface which, for example, can be used to
- [calculate the outgoing current for every node based on kirchhoff and provide as derived states `:_i_r` and `:_i_i`](https://github.com/PIK-ICoNe/NetworkDynamics.jl/blob/748b0e848deb1487048264753da768090d999a31/test/SolutionInspection_test.jl#L49-L57)
- [calculate the frequency `:_ω` based of the stored derivateives of `u_r` and `u_i` in the solution object](https://github.com/PIK-ICoNe/NetworkDynamics.jl/blob/748b0e848deb1487048264753da768090d999a31/test/SolutionInspection_test.jl#L34-L47)

### "observed" states
Not yet implemented in the prototype. The vertex and edge objects need two new fields: `observed_sym` and `observed_f`. The `observed_f` will be a function `f(u, edges, p, t)` which returns all the observed states for a given statevector. Should be nonbreaking, since those can be allways empty. For vertex and edge functions generated using BlockSystems/MTK this has the advantage of plotting arbtrary internal states using the same interface.

### Remarks on parameters
Often, `p` will change during the simulations in a callback. For direct states and states which are derived from normal states this isn't a problem. However, if one wants to calculate observed states (or static edge states for that matter) it is necessary to provide the correct parameters for each time. This information is not stored in the solution object. In that PR you can use
```julia
prob = ODEProblem(nd, p, ...)
pr = PRecord(prob)
...
function affect!(integrator)
    integrator.p = ...
    record!(pr, integrator)
end
...
```
which keeps track of parameter changes to replay them later.