### PR TITLE
keep track of unused parameters

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,8 +27,10 @@ jobs:
                            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}")
           PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
           PR_BODY=$(echo "$PR_DATA" | jq -r '.body')
+          # Ensure PR_BODY is single-line and sanitized for GitHub env vars
+          PR_BODY_ESCAPED=$(echo "$PR_BODY" | tr '\n' ' ' | tr '\r' ' ')
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV
-          echo "PR_BODY=$PR_BODY" >> $GITHUB_ENV
+          echo "PR_BODY=$PR_BODY_ESCAPED" >> $GITHUB_ENV
       - name: Check for '[no benchmark]'
         id: check
         run: |

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -37,7 +37,7 @@ Creates a callback condition for a [`ComponentCallback`].
 Consider a component model with states `[:u1, :u2]`, inputs `[:i]`, outputs
 `[:o]` and parameters `[:p1, :p2]`.
 
-    ComponentCondition([:u1, :o], [:p1]) do (u, p, t)
+    ComponentCondition([:u1, :o], [:p1]) do u, p, t
         # access states symbolicially or via int index
         u[:u1] == u[1]
         u[:o] == u[2]
@@ -81,7 +81,7 @@ Creates a callback condition for a [`ComponentCallback`].
 Consider a component model with states `[:u1, :u2]`, inputs `[:i]`, outputs
 `[:o]` and parameters `[:p1, :p2]`.
 
-    ComponentAffect([:u1, :o], [:p1]) do (u, p, ctx)
+    ComponentAffect([:u1, :o], [:p1]) do u, p, ctx
         u[:u1] = 0 # change the state
         p[:p1] = 1 # change the parameter
         @info "Changed :u1 and :p1 on vertex \$(ctx.vidx)" # access context

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -72,6 +72,18 @@ for md in [:default, :guess, :init, :bounds]
 end
 set_graphelement!(c::EdgeModel, p::Pair) = set_graphelement!(c, (;src=p.first, dst=p.second))
 
+"""
+    is_unused(c::ComponentModel, sym::Symbol)
+
+Checks if symbol `sym` is marked as unused (i.e. it does not appear in the equations of f and g explicitly).
+"""
+function is_unused(c::ComponentModel, sym::Symbol)
+    if has_metadata(c, sym, :unused)
+        get_metadata(c, sym, :unused)
+    else
+        false
+    end
+end
 
 #### default or init
 """
@@ -318,7 +330,13 @@ end
 function _append_states!(lns, cf, syms; sigdigits)
     fidx = length(lns)+1
     for sym in syms
-        str = "  &" * string(sym) * " &&= "
+        str = "  &"
+        if is_unused(cf, sym)
+            str *= styled"{gray:$(string(sym)) (unused)}"
+        else
+            str *= string(sym)
+        end
+        str *= " &&= "
         if has_default_or_init(cf, sym)
             val = get_default_or_init(cf, sym)
             val_str = str_significant(val; sigdigits, phantom_minus=true)

--- a/test/initialization_test.jl
+++ b/test/initialization_test.jl
@@ -48,6 +48,7 @@ end
             V=sqrt(u_r^2 + u_i^2), [description="Voltage magnitude"]
             ω_ref=0, [description="Reference frequency"]
             Pm, [guess=0.1,description="Mechanical Power"]
+            aux, [description="Auxiliary, unused parameter"]
         end
         @equations begin
             Dt(θ) ~ ω - ω_ref
@@ -66,6 +67,8 @@ end
     @test vf.symmetadata[:θ][:bounds] == [-π, π]
     @test vf.symmetadata[:i_r][:default] == 1
     @test vf.symmetadata[:i_i][:default] == 0.1
+    @test filter(p->NetworkDynamics.is_unused(vf, p), psym(vf)) == [:aux]
+    @test NetworkDynamics.has_default_or_init(vf, :aux) == false
 
     NetworkDynamics.initialize_component!(vf; verbose=true)
     @test NetworkDynamics.init_residual(vf) < 1e-8
@@ -77,6 +80,7 @@ end
     set_default!(vf, :ω, get_init(vf, :ω))
 
     NetworkDynamics.initialize_component!(vf; verbose=true)
+    dump_initial_state(vf)
 end
 
 @testset "test component initialization with bounds" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,8 @@ using ExplicitImports
 
 (isinteractive() ? includet : include)(joinpath(pkgdir(NetworkDynamics, "test", "testutils.jl")))
 
+haskey(ENV, "BUILDKITE") && @test CUDA.functional() # fail early in buildkite if cuda is not available
+
 @testset "NetworkDynamics Tests" begin
     @testset "Package Quality Tests" begin
         # print_explicit_imports(NetworkDynamics)


### PR DESCRIPTION
sometimes, parameters are not directly used in `f` and `g` function (i.e. the line limit used in callbacks).
Keep track of those (set `unused=true` metadata) and ignore them in component wise initialisation

[no benchmark]