### PR TITLE
fixes behavior of colors in inspector graphplot

### DIFF
--- a/NetworkDynamicsInspector/Project.toml
+++ b/NetworkDynamicsInspector/Project.toml
@@ -1,7 +1,7 @@
 name = "NetworkDynamicsInspector"
 uuid = "0a4713f2-d58f-43f2-b63b-1b5d5ee4e65a"
 authors = ["Hans Würfel <git@wuerfel.io>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"

--- a/NetworkDynamicsInspector/src/appstate.jl
+++ b/NetworkDynamicsInspector/src/appstate.jl
@@ -140,6 +140,8 @@ function set_graphplot!(; nstate = NotSpecified(),
                           ncolorrange = NotSpecified(),
                           ecolorrange = NotSpecified())
     sync()
+    estate = estate isa Symbol ? [estate] : estate
+    nstate = nstate isa Symbol ? [nstate] : nstate
     gp = appstate().graphplot
     set_maybe!(gp.nstate, nstate)
     set_maybe!(gp.estate, estate)

--- a/NetworkDynamicsInspector/test/runtests.jl
+++ b/NetworkDynamicsInspector/test/runtests.jl
@@ -133,6 +133,20 @@ end
         end
     end
 
+    @testset "change colorscheme" begin
+        sol = get_sol()
+        inspect(sol; display=ElectronDisp(), restart=true, reset=true)
+
+        @test NetworkDynamicsInspector._maxrange(sol, vidxs(sol, :, :M), false) == (1.0, 1.0)
+        @test NetworkDynamicsInspector._maxrange(sol, vidxs(sol, :, :M), true) == (0.0, 0.0)
+        @test NetworkDynamicsInspector._maxrange(sol, eidxs(sol, :, :active), false) == (0.0, 1.0)
+        @test NetworkDynamicsInspector._maxrange(sol, eidxs(sol, :, :active), true) == (-1.0, 0.0)
+
+        set_graphplot!(; estate=:active)
+        set_graphplot!(; estate_rel=true)
+        set_graphplot!(; estate_rel=false)
+    end
+
     @testset "Widget Tests" begin
         @safetestset "Multiselect Tests" begin include("multiselect_test.jl") end
         @safetestset "Slider Tests" begin include("slider_test.jl") end


### PR DESCRIPTION
- fixes rel switch behavior
- adds revers(thermal) colorscale for values within (-inf, 0)
- fixes colorrange update behavior (e.g.  before, certain switching back and forth lead to bounding box error in makie because the colorrange was set to (0,0))

cc @kafu16